### PR TITLE
feat: add additional completions

### DIFF
--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -48,28 +48,10 @@ local function is_correct_node(node, buf)
 	return true
 end
 
----@param node TSNode|nil
----@param buf integer
----@returns boolean
-local function has_correct_string(node, buf)
-	if node == nil then
-		return
-	end
-
-	local string_text = vim.treesitter.get_node_text(node, buf)
-	if not string_text:match('=="$') then
-		return
-	end
-
-	-- vim.treesitter.
-	return true
-end
-
 local function should_complete()
 	local node = vim.treesitter.get_node()
 	local buf = vim.api.nvim_get_current_buf()
 	return is_correct_node(node, buf)
-	-- return is_correct_node(node, buf) and has_correct_string(node, buf)
 end
 
 ---@type { [string]: lsp.CompletionResponse|nil }

--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -2,150 +2,150 @@
 ---@param buf integer
 ---@returns boolean
 local function is_correct_node(node, buf)
-    if node == nil then
-        return false
-    end
+	if node == nil then
+		return false
+	end
 
-    -- Case 1:
-    -- | [project]
-    -- | dependencies = [
-    -- |     "<package> *== *<version>",
-    -- | ]
-    --                  OR
-    -- | [project.optional-dependencies]
-    -- | my-extras = [
-    -- |     "<package> *== *<version>",
-    -- | ]
-    -- This also catches when the "<package> *== *<version>" string is not closed
-    repeat
-        if node:type() ~= "string" and node:type() ~= "ERROR" then
-            break
-        end
+	-- Case 1:
+	-- | [project]
+	-- | dependencies = [
+	-- |     "<package> *== *<version>",
+	-- | ]
+	--             OR
+	-- | [project.optional-dependencies]
+	-- | my-extras = [
+	-- |     "<package> *== *<version>",
+	-- | ]
+	-- This also catches when the "<package> *== *<version>" string is not closed
+	repeat
+		if node:type() ~= "string" and node:type() ~= "ERROR" then
+			break
+		end
 
-        local parent = node:parent()
-        if parent:type() ~= "array" then
-            break
-        end
+		local parent = node:parent()
+		if parent:type() ~= "array" then
+			break
+		end
 
-        local grandparent = parent:parent()
-        if grandparent:type() ~= "pair" then
-            break
-        end
-        local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
+		local grandparent = parent:parent()
+		if grandparent:type() ~= "pair" then
+			break
+		end
+		local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
 
-        local greatgrandparent = grandparent:parent()
-        if greatgrandparent:type() ~= "table" then
-            break
-        end
-        local greatgrandparent_name = vim.treesitter.get_node_text(greatgrandparent:named_child(), buf)
+		local greatgrandparent = grandparent:parent()
+		if greatgrandparent:type() ~= "table" then
+			break
+		end
+		local greatgrandparent_name = vim.treesitter.get_node_text(greatgrandparent:named_child(), buf)
 
-        if not string.find(greatgrandparent_name, "project") then
-            break
-        end
-        if not string.find(grandparent_name, "dependencies") then
-            if not string.find(greatgrandparent_name, "dependencies") then
-                break
-            end
-        end
+		if not string.find(greatgrandparent_name, "project") then
+			break
+		end
+		if not string.find(grandparent_name, "dependencies") then
+			if not string.find(greatgrandparent_name, "dependencies") then
+				break
+			end
+		end
 
-        return true
-    until true
+		return true
+	until true
 
-    -- Case 2:
-    -- | [table.name.containing.dependencies]
-    -- | <package> *= *"<version>"
-    -- This also catches when the "<version>" string is not closed
-    repeat
-        if node:type() == "ERROR" then
+	-- Case 2:
+	-- | [table.name.containing.dependencies]
+	-- | <package> *= *"<version>"
+	-- This also catches when the "<version>" string is not closed
+	repeat
+		if node:type() == "ERROR" then
 
-            local last_sibling = node:prev_sibling()
-            if last_sibling:type() ~= "table" then
-                break
-            end
-            local last_sibling_name = vim.treesitter.get_node_text(last_sibling:named_child(), buf)
-            if not string.find(last_sibling_name, "dependencies") then
-                break
-            end
+			local last_sibling = node:prev_sibling()
+			if last_sibling:type() ~= "table" then
+				break
+			end
+			local last_sibling_name = vim.treesitter.get_node_text(last_sibling:named_child(), buf)
+			if not string.find(last_sibling_name, "dependencies") then
+				break
+			end
 
-            return true
+			return true
 
-        end
+		end
 
-        if node:type() ~= "string" then
-            break
-        end
+		if node:type() ~= "string" then
+			break
+		end
 
-        local parent = node:parent()
-        if parent:type() ~= "pair" then
-            break
-        end
+		local parent = node:parent()
+		if parent:type() ~= "pair" then
+			break
+		end
 
-        local grandparent = parent:parent()
-        if grandparent:type() ~= "table" then
-            break
-        end
-        local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
-        if not string.find(grandparent_name, "dependencies") then
-            break
-        end
+		local grandparent = parent:parent()
+		if grandparent:type() ~= "table" then
+			break
+		end
+		local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
+		if not string.find(grandparent_name, "dependencies") then
+			break
+		end
 
-        return true
-    until true
+		return true
+	until true
 
-    return false
+	return false
 end
 
 local function should_complete()
-    local node = vim.treesitter.get_node()
-    local buf = vim.api.nvim_get_current_buf()
-    return is_correct_node(node, buf)
+	local node = vim.treesitter.get_node()
+	local buf = vim.api.nvim_get_current_buf()
+	return is_correct_node(node, buf)
 end
 
 ---@type { [string]: lsp.CompletionResponse|nil }
 local cmp_cache = {}
 
 local function sorted_iter_by_key(t)
-    local i = {}
-    for k in next, t do
-        table.insert(i, k)
-    end
-    table.sort(i)
-    return function()
-        return table.remove(i)
-    end
+	local i = {}
+	for k in next, t do
+		table.insert(i, k)
+	end
+	table.sort(i)
+	return function()
+		return table.remove(i)
+	end
 end
 
 ---@name string|nil
 ---@returns lsp.CompletionResponse|nil
 local function complete(name)
-    if cmp_cache[name] then
-        return cmp_cache[name]
-    end
+	if cmp_cache[name] then
+		return cmp_cache[name]
+	end
 
-    local response = require("plenary.curl").get(
-        ("https://pypi.org/pypi/%s/json"):format(name),
-        { headers = {
-            content_type = "application/json",
-        } }
-    )
+	local response = require("plenary.curl").get(
+		("https://pypi.org/pypi/%s/json"):format(name),
+		{ headers = {
+			content_type = "application/json",
+		} }
+	)
 
-    local res_json = vim.fn.json_decode(response.body)
-    if res_json == nil or res_json.releases == nil then
-        return
-    end
+	local res_json = vim.fn.json_decode(response.body)
+	if res_json == nil or res_json.releases == nil then
+		return
+	end
 
-    local result = {}
-    local i = 0
-    for version in sorted_iter_by_key(res_json.releases) do
-        table.insert(result, { label = version, sortText = string.format("%04d", i) })
-        i = i + 1
-    end
+	local result = {}
+	local i = 0
+	for version in sorted_iter_by_key(res_json.releases) do
+		table.insert(result, { label = version, sortText = string.format("%04d", i) })
+		i = i + 1
+	end
 
-    cmp_cache[name] = result
-    return result
+	cmp_cache[name] = result
+	return result
 end
 
 return {
-    should_complete = should_complete,
-    complete = complete,
+	should_complete = should_complete,
+	complete = complete,
 }

--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -2,9 +2,9 @@
 ---@param buf integer
 ---@returns boolean
 local function is_correct_node(node, buf)
-	if node == nil then
-		return false
-	end
+    if node == nil then
+        return false
+    end
 
     -- Case 1:
     -- | [project]
@@ -18,35 +18,35 @@ local function is_correct_node(node, buf)
     -- | ]
     -- This also catches when the "<package> *== *<version>" string is not closed
     repeat
-	    if node:type() ~= "string" and node:type() ~= "ERROR" then
-	    	break
-	    end
+        if node:type() ~= "string" and node:type() ~= "ERROR" then
+            break
+        end
 
         local parent = node:parent()
-	    if parent:type() ~= "array" then
-	    	break
-	    end
+        if parent:type() ~= "array" then
+            break
+        end
 
         local grandparent = parent:parent()
-	    if grandparent:type() ~= "pair" then
-	    	break
-	    end
-	    local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
+        if grandparent:type() ~= "pair" then
+            break
+        end
+        local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
 
         local greatgrandparent = grandparent:parent()
-	    if greatgrandparent:type() ~= "table" then
-	    	break
-	    end
-	    local greatgrandparent_name = vim.treesitter.get_node_text(greatgrandparent:named_child(), buf)
+        if greatgrandparent:type() ~= "table" then
+            break
+        end
+        local greatgrandparent_name = vim.treesitter.get_node_text(greatgrandparent:named_child(), buf)
 
-		if not string.find(greatgrandparent_name, "project") then
-			break
-		end
-		if not string.find(grandparent_name, "dependencies") then
-		    if not string.find(greatgrandparent_name, "dependencies") then
-		    	break
-		    end
-		end
+        if not string.find(greatgrandparent_name, "project") then
+            break
+        end
+        if not string.find(grandparent_name, "dependencies") then
+            if not string.find(greatgrandparent_name, "dependencies") then
+                break
+            end
+        end
 
         return true
     until true
@@ -56,38 +56,38 @@ local function is_correct_node(node, buf)
     -- | <package> *= *"<version>"
     -- This also catches when the "<version>" string is not closed
     repeat
-	    if node:type() == "ERROR" then
+        if node:type() == "ERROR" then
 
             local last_sibling = node:prev_sibling()
-	        if last_sibling:type() ~= "table" then
-	        	break
-	        end
-	        local last_sibling_name = vim.treesitter.get_node_text(last_sibling:named_child(), buf)
-		    if not string.find(last_sibling_name, "dependencies") then
-		    	break
-		    end
+            if last_sibling:type() ~= "table" then
+                break
+            end
+            local last_sibling_name = vim.treesitter.get_node_text(last_sibling:named_child(), buf)
+            if not string.find(last_sibling_name, "dependencies") then
+                break
+            end
 
             return true
 
-	    end
+        end
 
-	    if node:type() ~= "string" then
-	    	break
-	    end
+        if node:type() ~= "string" then
+            break
+        end
 
         local parent = node:parent()
-	    if parent:type() ~= "pair" then
-	    	break
-	    end
+        if parent:type() ~= "pair" then
+            break
+        end
 
         local grandparent = parent:parent()
-	    if grandparent:type() ~= "table" then
-	    	break
-	    end
-	    local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
-		if not string.find(grandparent_name, "dependencies") then
-			break
-		end
+        if grandparent:type() ~= "table" then
+            break
+        end
+        local grandparent_name = vim.treesitter.get_node_text(grandparent:named_child(), buf)
+        if not string.find(grandparent_name, "dependencies") then
+            break
+        end
 
         return true
     until true
@@ -96,56 +96,56 @@ local function is_correct_node(node, buf)
 end
 
 local function should_complete()
-	local node = vim.treesitter.get_node()
-	local buf = vim.api.nvim_get_current_buf()
-	return is_correct_node(node, buf)
+    local node = vim.treesitter.get_node()
+    local buf = vim.api.nvim_get_current_buf()
+    return is_correct_node(node, buf)
 end
 
 ---@type { [string]: lsp.CompletionResponse|nil }
 local cmp_cache = {}
 
 local function sorted_iter_by_key(t)
-	local i = {}
-	for k in next, t do
-		table.insert(i, k)
-	end
-	table.sort(i)
-	return function()
-		return table.remove(i)
-	end
+    local i = {}
+    for k in next, t do
+        table.insert(i, k)
+    end
+    table.sort(i)
+    return function()
+        return table.remove(i)
+    end
 end
 
 ---@name string|nil
 ---@returns lsp.CompletionResponse|nil
 local function complete(name)
-	if cmp_cache[name] then
-		return cmp_cache[name]
-	end
+    if cmp_cache[name] then
+        return cmp_cache[name]
+    end
 
-	local response = require("plenary.curl").get(
-		("https://pypi.org/pypi/%s/json"):format(name),
-		{ headers = {
-			content_type = "application/json",
-		} }
-	)
+    local response = require("plenary.curl").get(
+        ("https://pypi.org/pypi/%s/json"):format(name),
+        { headers = {
+            content_type = "application/json",
+        } }
+    )
 
-	local res_json = vim.fn.json_decode(response.body)
-	if res_json == nil or res_json.releases == nil then
-		return
-	end
+    local res_json = vim.fn.json_decode(response.body)
+    if res_json == nil or res_json.releases == nil then
+        return
+    end
 
-	local result = {}
-	local i = 0
-	for version in sorted_iter_by_key(res_json.releases) do
-		table.insert(result, { label = version, sortText = string.format("%04d", i) })
-		i = i + 1
-	end
+    local result = {}
+    local i = 0
+    for version in sorted_iter_by_key(res_json.releases) do
+        table.insert(result, { label = version, sortText = string.format("%04d", i) })
+        i = i + 1
+    end
 
-	cmp_cache[name] = result
-	return result
+    cmp_cache[name] = result
+    return result
 end
 
 return {
-	should_complete = should_complete,
-	complete = complete,
+    should_complete = should_complete,
+    complete = complete,
 }

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -2,23 +2,23 @@ local source = {}
 
 ---@return string
 function source:get_debug_name()
-	return "pypi"
+    return "pypi"
 end
 
 ---@return boolean
 function source:is_available()
-	local filename = vim.fn.expand("%:t")
-	return filename == "pyproject.toml"
+    local filename = vim.fn.expand("%:t")
+    return filename == "pyproject.toml"
 end
 
 ---@return string
 function source:get_keyword_pattern()
-	return [[\k\+]]
+    return [[\k\+]]
 end
 
 ---@return string[]
 function source:get_trigger_characters()
-	return {
+    return {
         -- Part way through a version
         ".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
         -- Case 1
@@ -31,42 +31,42 @@ end
 ---@param params cmp.SourceCompletionApiParams
 ---@param callback fun(response: lsp.CompletionResponse|nil)
 function source:complete(params, callback)
-	local core = require("cmp-pypi.core")
+    local core = require("cmp-pypi.core")
 
-	local line = params.context.cursor_before_line
+    local line = params.context.cursor_before_line
 
-	if not core.should_complete() then
-		return callback()
-	end
+    if not core.should_complete() then
+        return callback()
+    end
 
-	-- `package == version` for 0 to any number of spaces
-	local name, _ = string.match(line, '([%w_%-]+)%s*==%s*([^"= ]*)$')
+    -- `package == version` for 0 to any number of spaces
+    local name, _ = string.match(line, '([%w_%-]+)%s*==%s*([^"= ]*)$')
 
-	if not name then
-		-- `package = "version"` for 0 to any number of spaces
-		name, _ = string.match(line, '^([%w_%-]+)%s*=%s*"([^"]*)$')
+    if not name then
+        -- `package = "version"` for 0 to any number of spaces
+        name, _ = string.match(line, '^([%w_%-]+)%s*=%s*"([^"]*)$')
 
-		if not name then
-			return callback()
-		end
-	end
+        if not name then
+            return callback()
+        end
+    end
 
-	vim.schedule(function()
-		local result = core.complete(name)
-		callback(result)
-	end)
+    vim.schedule(function()
+        local result = core.complete(name)
+        callback(result)
+    end)
 end
 
 ---@param completion_item lsp.CompletionItem
 ---@param callback function
 function source:resolve(completion_item, callback)
-	callback(completion_item)
+    callback(completion_item)
 end
 
 ---@param completion_item lsp.CompletionItem
 ---@param callback function
 function source:execute(completion_item, callback)
-	callback(completion_item)
+    callback(completion_item)
 end
 
 return source

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -31,10 +31,12 @@ function source:complete(params, callback)
 
 	local line = params.context.cursor_before_line
 
-	local name, _ = string.match(line, '([^"]+)==([^"=]*)$')
-
+	-- `package == version` for 0 to any number of spaces
+	local name, _ = string.match(line, '([^" ]+) *== *([^"= ]*)$')
+	
 	if not name then
-		name, _ = string.match(line, '^([^= ]+)%s?=%s?"([^"]*)$')
+		-- `package = "version"` for 0 to any number of spaces
+		name, _ = string.match(line, '^([^= ]+) *= *"([^"]*)$')
 
 		if not name then
 			return callback()

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -32,11 +32,11 @@ function source:complete(params, callback)
 	local line = params.context.cursor_before_line
 
 	-- `package == version` for 0 to any number of spaces
-	local name, _ = string.match(line, '([^" ]+) *== *([^"= ]*)$')
-	
+	local name, _ = string.match(line, '([^" ]+)%s==%s([^"= ]*)$')
+
 	if not name then
 		-- `package = "version"` for 0 to any number of spaces
-		name, _ = string.match(line, '^([^= ]+) *= *"([^"]*)$')
+		name, _ = string.match(line, '^([^= ]+)%s=%s"([^"]*)$')
 
 		if not name then
 			return callback()

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -33,11 +33,11 @@ end
 function source:complete(params, callback)
 	local core = require("cmp-pypi.core")
 
-	local line = params.context.cursor_before_line
-
 	if not core.should_complete() then
 		return callback()
 	end
+
+	local line = params.context.cursor_before_line
 
 	-- `package == version` for 0 to any number of spaces
 	local name, _ = string.match(line, '([%w_%-]+)%s*==%s*([^"= ]*)$')

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -18,25 +18,33 @@ end
 
 ---@return string[]
 function source:get_trigger_characters()
-	return { "=", ".", "^", "~" }
+	return {
+        -- Part way through a version
+        ".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+        -- Case 1
+        "=", " ",
+        -- Case 2
+        "^", "~", "\"",
+    }
 end
 
 ---@param params cmp.SourceCompletionApiParams
 ---@param callback fun(response: lsp.CompletionResponse|nil)
 function source:complete(params, callback)
 	local core = require("cmp-pypi.core")
+
+	local line = params.context.cursor_before_line
+
 	if not core.should_complete() then
 		return callback()
 	end
 
-	local line = params.context.cursor_before_line
-
 	-- `package == version` for 0 to any number of spaces
-	local name, _ = string.match(line, '([^" ]+)%s==%s([^"= ]*)$')
+	local name, _ = string.match(line, '([%w_%-]+)%s*==%s*([^"= ]*)$')
 
 	if not name then
 		-- `package = "version"` for 0 to any number of spaces
-		name, _ = string.match(line, '^([^= ]+)%s=%s"([^"]*)$')
+		name, _ = string.match(line, '^([%w_%-]+)%s*=%s*"([^"]*)$')
 
 		if not name then
 			return callback()

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -2,71 +2,71 @@ local source = {}
 
 ---@return string
 function source:get_debug_name()
-    return "pypi"
+	return "pypi"
 end
 
 ---@return boolean
 function source:is_available()
-    local filename = vim.fn.expand("%:t")
-    return filename == "pyproject.toml"
+	local filename = vim.fn.expand("%:t")
+	return filename == "pyproject.toml"
 end
 
 ---@return string
 function source:get_keyword_pattern()
-    return [[\k\+]]
+	return [[\k\+]]
 end
 
 ---@return string[]
 function source:get_trigger_characters()
-    return {
-        -- Part way through a version
-        ".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-        -- Case 1
-        "=", " ",
-        -- Case 2
-        "^", "~", "\"",
-    }
+	return {
+		-- Part way through a version
+		".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+		-- Case 1
+		"=", " ",
+		-- Case 2
+		"^", "~", "\"",
+	}
 end
 
 ---@param params cmp.SourceCompletionApiParams
 ---@param callback fun(response: lsp.CompletionResponse|nil)
 function source:complete(params, callback)
-    local core = require("cmp-pypi.core")
+	local core = require("cmp-pypi.core")
 
-    local line = params.context.cursor_before_line
+	local line = params.context.cursor_before_line
 
-    if not core.should_complete() then
-        return callback()
-    end
+	if not core.should_complete() then
+		return callback()
+	end
 
-    -- `package == version` for 0 to any number of spaces
-    local name, _ = string.match(line, '([%w_%-]+)%s*==%s*([^"= ]*)$')
+	-- `package == version` for 0 to any number of spaces
+	local name, _ = string.match(line, '([%w_%-]+)%s*==%s*([^"= ]*)$')
 
-    if not name then
-        -- `package = "version"` for 0 to any number of spaces
-        name, _ = string.match(line, '^([%w_%-]+)%s*=%s*"([^"]*)$')
+	if not name then
+		-- `package = "version"` for 0 to any number of spaces
+		name, _ = string.match(line, '^([%w_%-]+)%s*=%s*"([^"]*)$')
 
-        if not name then
-            return callback()
-        end
-    end
+		if not name then
+			return callback()
+		end
+	end
 
-    vim.schedule(function()
-        local result = core.complete(name)
-        callback(result)
-    end)
+	vim.schedule(function()
+		local result = core.complete(name)
+		callback(result)
+	end)
 end
 
 ---@param completion_item lsp.CompletionItem
 ---@param callback function
 function source:resolve(completion_item, callback)
-    callback(completion_item)
+	callback(completion_item)
 end
 
 ---@param completion_item lsp.CompletionItem
 ---@param callback function
 function source:execute(completion_item, callback)
-    callback(completion_item)
+	callback(completion_item)
 end
 
 return source


### PR DESCRIPTION
Hi,

I recently found this plugin and have liked using it.
I found some issues with when it could trigger completions, so made the following changes.

In these examples, vertical bar (`|`) indicates the cursor position:

- Removed the unused `has_correct_string` function.
- Completions can now occur if the string is unterminated.
  - This allows you to complete from states like:
    - `package = "|`
    - `"package == |"`
- Completions can now occur on numbers on valid line matches.
  - This allows you to complete from `"package == 1|"`, which wasn't previously possible (you had to complete from a `.`)
- Completions now work on the `project.optional-dependencies` table.