### PR TITLE
feat: change ordering to order by PyPi upload date

### DIFF
--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -107,20 +107,20 @@ end
 local cmp_cache = {}
 
 local function versions_sorted_by_upload_date_descending(releases)
-    local pq = PriorityQueue("max")
+	local pq = PriorityQueue("max")
 
-    for version, releases_list in pairs(releases) do
-        if type(releases_list) == "table" then
-            for _, release_info in ipairs(releases_list) do
-                if type(release_info) == "table" and release_info.upload_time_iso_8601 then
-                    pq:enqueue(version, release_info.upload_time_iso_8601)
-                    break
-                end
-            end
-        end
-    end
+	for version, releases_list in pairs(releases) do
+		if type(releases_list) == "table" then
+			for _, release_info in ipairs(releases_list) do
+				if type(release_info) == "table" and release_info.upload_time_iso_8601 then
+					pq:enqueue(version, release_info.upload_time_iso_8601)
+					break
+				end
+			end
+		end
+	end
 
-    return pq
+	return pq
 end
 
 ---@name string|nil
@@ -133,10 +133,10 @@ local function complete(name)
 	local response = require("plenary.curl").get(
 		("https://pypi.org/pypi/%s/json"):format(name),
 		{
-            headers = {
-			    content_type = "application/json",
-		    },
-        }
+			headers = {
+				content_type = "application/json",
+			},
+		}
 	)
 
 	local res_json = vim.fn.json_decode(response.body)
@@ -144,11 +144,11 @@ local function complete(name)
 		return
 	end
 
-    local versions_by_date = versions_sorted_by_upload_date_descending(res_json.releases)
+	local versions_by_date = versions_sorted_by_upload_date_descending(res_json.releases)
 
 	local result = {}
-    for i = 1, #versions_by_date do
-        local version = versions_by_date:dequeue()
+	for i = 1, #versions_by_date do
+		local version = versions_by_date:dequeue()
 		table.insert(result, { label = version, sortText = string.format("%04d", i) })
 	end
 

--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -124,11 +124,17 @@ local function version_sorter(v1, v2)
         local part1 = tonumber(p1[i])
         local part2 = tonumber(p2[i])
 
-        -- Use strings in comparison if either can't be a number
-        if (not part1) or (not part2) then
-            part1 = p1[i]
-            part2 = p2[i]
+        -- If one can't be interpreted as an integer, assume the other is bigger
+        if (not part1) and part2 then
+            return true
         end
+        if part1 and (not part2) then
+            return false
+        end
+
+        -- Use both as strings if neither can be integers
+        part1 = p1[i]
+        part2 = p2[i]
 
         -- If one is shorter than the other, consider the longer one to be bigger
         if (not part1) and part2 then

--- a/lua/cmp-pypi/priority_queue.lua
+++ b/lua/cmp-pypi/priority_queue.lua
@@ -1,0 +1,236 @@
+-- [[
+-- This code was taken from: https://github.com/iskolbin/lpriorityqueue
+-- ]]
+
+--[[
+
+ PriorityQueue - v1.0.1 - public domain Lua priority queue
+ implemented with indirect binary heap
+ no warranty implied; use at your own risk
+
+ based on binaryheap library (github.com/iskolbin/binaryheap)
+
+ author: Ilya Kolbin (iskolbin@gmail.com)
+ url: github.com/iskolbin/priorityqueue
+
+ See documentation in README file.
+
+ COMPATIBILITY
+
+ Lua 5.1, 5.2, 5.3, LuaJIT 1, 2
+
+ LICENSE
+
+ This software is dual-licensed to the public domain and under the following
+ license: you are granted a perpetual, irrevocable license to copy, modify,
+ publish, and distribute this file as you see fit.
+
+--]]
+
+local floor, setmetatable = math.floor, setmetatable
+
+local function siftup( self, from )
+	local items, priorities, indices, higherpriority = self, self._priorities, self._indices, self._higherpriority
+	local index = from
+	local parent = floor( index / 2 )
+	while index > 1 and higherpriority( priorities[index], priorities[parent] ) do
+		priorities[index], priorities[parent] = priorities[parent], priorities[index]
+		items[index], items[parent] = items[parent], items[index]
+		indices[items[index]], indices[items[parent]] = index, parent
+		index = parent
+		parent = floor( index / 2 )
+	end
+	return index
+end
+
+local function siftdown( self, limit )
+	local items, priorities, indices, higherpriority, size = self, self._priorities, self._indices, self._higherpriority, self._size
+	for index = limit, 1, -1 do
+		local left = index + index
+		local right = left + 1
+		while left <= size do
+			local smaller = left
+			if right <= size and higherpriority( priorities[right], priorities[left] ) then
+				smaller = right
+			end
+			if higherpriority( priorities[smaller], priorities[index] ) then
+				items[index], items[smaller] = items[smaller], items[index]
+				priorities[index], priorities[smaller] = priorities[smaller], priorities[index]
+				indices[items[index]], indices[items[smaller]] = index, smaller
+			else
+				break
+			end
+			index = smaller
+			left = index + index
+			right = left + 1
+		end
+	end
+end
+
+local PriorityQueueMt
+
+local PriorityQueue = {}
+
+local function minishigher( a, b )
+	return a < b
+end
+
+local function maxishigher( a, b )
+	return a > b
+end
+
+function PriorityQueue.new( priority_or_array )
+	local t = type( priority_or_array )
+	local higherpriority = minishigher
+	
+	if t == 'table' then
+		higherpriority = priority_or_array.higherpriority or higherpriority
+	elseif t == 'function' or t == 'string' then
+		higherpriority = priority_or_array
+	elseif t ~= 'nil' then
+		local msg = 'Wrong argument type to PriorityQueue.new, it must be table or function or string, has: %q'
+		error( msg:format( t ))
+	end
+
+	if type( higherpriority ) == 'string' then
+		if higherpriority == 'min' then
+			higherpriority = minishigher
+		elseif higherpriority == 'max' then
+			higherpriority = maxishigher
+		else
+			local msg = 'Wrong string argument to PriorityQueue.new, it must be "min" or "max", has: %q'
+			error( msg:format( tostring( higherpriority )))
+		end
+	end
+
+	local self = setmetatable( {
+		_priorities = {},
+		_indices = {},
+		_size = 0,
+		_higherpriority = higherpriority or minishigher
+	}, PriorityQueueMt )
+
+	if t == 'table' then
+		self:batchenq( priority_or_array )
+	end
+
+	return self
+end
+
+function PriorityQueue:enqueue( item, priority )
+	local items, priorities, indices = self, self._priorities, self._indices
+	if indices[item] ~= nil then
+		error( 'Item ' .. tostring(indices[item]) .. ' is already in the heap' )
+	end
+	local size = self._size + 1
+	self._size = size	
+	items[size], priorities[size], indices[item] = item, priority, size
+	siftup( self, size ) 
+	return self
+end
+
+function PriorityQueue:remove( item )
+	local index = self._indices[item]
+	if index ~= nil then
+		local size = self._size
+		local items, priorities, indices = self, self._priorities, self._indices
+		indices[item] = nil
+		if size == index then
+			items[size], priorities[size] = nil, nil
+			self._size = size - 1
+		else
+			local lastitem = items[size]
+			items[index], priorities[index] = items[size], priorities[size]
+			items[size], priorities[size] = nil, nil
+			indices[lastitem] = index
+			size = size - 1
+			self._size = size
+			if size > 1 then
+				siftdown( self, siftup( self, index )) 
+			end
+		end
+		return true
+	else
+		return false
+	end
+end
+
+function PriorityQueue:contains( item )
+	return self._indices[item] ~= nil
+end
+
+function PriorityQueue:update( item, priority )
+	local ok = self:remove( item )
+	if ok then
+		self:enqueue( item, priority )
+		return true
+	else
+		return false
+	end
+end
+
+function PriorityQueue:dequeue()
+	local size = self._size
+	
+	assert( size > 0, 'Heap is empty' )
+	
+	local items, priorities, indices = self, self._priorities, self._indices
+	local item, priority = items[1], priorities[1]
+	indices[item] = nil
+
+	if size > 1 then
+		local newitem = items[size]
+		items[1], priorities[1] = newitem, priorities[size]
+		items[size], priorities[size] = nil, nil
+		indices[newitem] = 1
+		size = size - 1
+		self._size = size
+		siftdown( self, 1 )
+	else
+		items[1], priorities[1] = nil, nil
+		self._size = 0
+	end
+
+	return item, priority
+end
+
+function PriorityQueue:peek()
+	return self[1], self._priorities[1]
+end
+	
+function PriorityQueue:len()
+	return self._size
+end
+
+function PriorityQueue:empty()
+	return self._size <= 0
+end
+
+function PriorityQueue:batchenq( iparray )
+	local items, priorities, indices = self, self._priorities, self._indices
+	local size = self._size
+	for i = 1, #iparray, 2 do
+		local item, priority = iparray[i], iparray[i+1]
+		if indices[item] ~= nil then
+			error( 'Item ' .. tostring(indices[item]) .. ' is already in the heap' )
+		end
+		size = size + 1
+		items[size], priorities[size] = item, priority
+		indices[item] = size
+	end
+	self._size = size
+	if size > 1 then
+		siftdown( self, floor( size / 2 ))
+	end
+end
+
+PriorityQueueMt = {
+	__index = PriorityQueue,
+	__len = PriorityQueue.len,
+}
+      
+return setmetatable( PriorityQueue, {
+	__call = function( _, ... )
+		return PriorityQueue.new( ... )
+	end
+} )


### PR DESCRIPTION
This MR changes the order of the results to show the newest first.

This is achieved by using a priority queue that I found on [github](https://github.com/iskolbin/lpriorityqueue) with permissive use rights, and then using the `upload_time_iso_8601` field from the PyPi JSON response as the priority for the queue.

This has the added benefit of substantially speeding up the sorting process, as we are no longer building the list and then sorting it (the queue sorts as the items are entered).

---

Potential breaking change:

- If a version does not have any associated artefacts, or none of those artefacts have an `upload_time_iso_8601` field, then it will no longer be displayed by `cmp`.
  - I've only seen this happen with very old versions.