### PR TITLE
feat: ignore yanked versions, ignore packages with newer `requires-python`

### DIFF
--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -158,17 +158,18 @@ local function versions_sorted_by_upload_date_descending(releases, node, buf)
 					if release_info.requires_python and release_info.requires_python ~= vim.NIL then
 						package_python = parse_pypi_package_python_version(release_info.requires_python)
 					end
-					local skip = false
-					skip = skip or release_info.yanked
 					local requires_python = get_requires_python(node, buf)
-					skip = skip or (
-						package_python ~= nil
-						and requires_python ~= nil
-						and (
-							package_python.major > requires_python.major
-							or (
-								package_python.major == requires_python.major
-								and package_python.minor > requires_python.minor
+					local skip = (
+						release_info.yanked
+						or (
+							package_python ~= nil
+							and requires_python ~= nil
+							and (
+								package_python.major > requires_python.major
+								or (
+									package_python.major == requires_python.major
+									and package_python.minor > requires_python.minor
+								)
 							)
 						)
 					)

--- a/lua/cmp-pypi/core.lua
+++ b/lua/cmp-pypi/core.lua
@@ -97,24 +97,85 @@ local function is_correct_node(node, buf)
 	return false
 end
 
-local function should_complete()
-	local node = vim.treesitter.get_node()
-	local buf = vim.api.nvim_get_current_buf()
-	return is_correct_node(node, buf)
+local function parse_python_version(str, offset)
+	local ret = nil
+	str = str:gsub("%s+", "")
+	if str:find(">=") ~= nil and str:find(",") == nil then
+		local separator_start, _ = str:find("%.")
+		ret = {}
+		ret["major"] = tonumber(str:sub(3 + offset, separator_start - 1))
+		ret["minor"] = tonumber(str:sub(separator_start + 1, -1 - offset))
+	end
+	return ret
+end
+
+local function parse_pyproject_python_version(str)
+	return parse_python_version(str, 1)
+end
+
+local function parse_pypi_package_python_version(str)
+	return parse_python_version(str, 0)
+end
+
+---@type { [string]: lsp.CompletionResponse|nil }
+local var_cache = {}
+
+local function get_requires_python(node, buf)
+	if var_cache["requires-python"] then
+		return var_cache["requires-python"]
+	end
+	local tree_root = node:tree():root()
+	local python_version_query = vim.treesitter.query.parse("toml", [[
+		(document
+		  (table
+			(pair
+			  (bare_key) @key-name (#eq? @key-name "requires-python")
+			  (string) @value
+			)
+		  )
+		)
+	]])
+	for id, requires_node, _ in python_version_query:iter_captures(tree_root, buf) do
+		if id == 2 then
+			local raw_text = vim.treesitter.get_node_text(requires_node, buf)
+			var_cache["requires-python"] = parse_pyproject_python_version(raw_text)
+		end
+	end
+	return var_cache["requires-python"]
 end
 
 ---@type { [string]: lsp.CompletionResponse|nil }
 local cmp_cache = {}
 
-local function versions_sorted_by_upload_date_descending(releases)
+local function versions_sorted_by_upload_date_descending(releases, node, buf)
 	local pq = PriorityQueue("max")
 
 	for version, releases_list in pairs(releases) do
 		if type(releases_list) == "table" then
 			for _, release_info in ipairs(releases_list) do
 				if type(release_info) == "table" and release_info.upload_time_iso_8601 then
-					pq:enqueue(version, release_info.upload_time_iso_8601)
-					break
+					local package_python = nil
+					if release_info.requires_python and release_info.requires_python ~= vim.NIL then
+						package_python = parse_pypi_package_python_version(release_info.requires_python)
+					end
+					local skip = false
+					skip = skip or release_info.yanked
+					local requires_python = get_requires_python(node, buf)
+					skip = skip or (
+						package_python ~= nil
+						and requires_python ~= nil
+						and (
+							package_python.major > requires_python.major
+							or (
+								package_python.major == requires_python.major
+								and package_python.minor > requires_python.minor
+							)
+						)
+					)
+					if not skip then
+						pq:enqueue(version, release_info.upload_time_iso_8601)
+						break
+					end
 				end
 			end
 		end
@@ -125,7 +186,7 @@ end
 
 ---@name string|nil
 ---@returns lsp.CompletionResponse|nil
-local function complete(name)
+local function complete(name, node, buf)
 	if cmp_cache[name] then
 		return cmp_cache[name]
 	end
@@ -144,7 +205,7 @@ local function complete(name)
 		return
 	end
 
-	local versions_by_date = versions_sorted_by_upload_date_descending(res_json.releases)
+	local versions_by_date = versions_sorted_by_upload_date_descending(res_json.releases, node, buf)
 
 	local result = {}
 	for i = 1, #versions_by_date do
@@ -157,6 +218,7 @@ local function complete(name)
 end
 
 return {
-	should_complete = should_complete,
 	complete = complete,
+	get_requires_python = get_requires_python,
+	is_correct_node = is_correct_node,
 }

--- a/lua/cmp-pypi/init.lua
+++ b/lua/cmp-pypi/init.lua
@@ -33,7 +33,10 @@ end
 function source:complete(params, callback)
 	local core = require("cmp-pypi.core")
 
-	if not core.should_complete() then
+	local node = vim.treesitter.get_node()
+	local buf = vim.api.nvim_get_current_buf()
+
+	if not core.is_correct_node(node, buf) then
 		return callback()
 	end
 
@@ -52,7 +55,7 @@ function source:complete(params, callback)
 	end
 
 	vim.schedule(function()
-		local result = core.complete(name)
+		local result = core.complete(name, node, buf)
 		callback(result)
 	end)
 end


### PR DESCRIPTION
- No longer recommend versions of a package that are marked as yanked.
- No longer recommend versions of a package that have a newer `requires-python` than your `pyproject.toml` has.
  - Note: This will only read `requires-python` values that start with `>=` and contain no commas.
    - If either your `requires-python` or the package doesn't obey this, then you will still be recommended those versions.
  - Note: If `requires-python` is changed after the plugin gets the JSON manifest for a package, recommendations will still be made for bad versions.
    - The editor has to be closed and reopened to correct this.